### PR TITLE
Interpolation on result pages

### DIFF
--- a/app_controller.rb
+++ b/app_controller.rb
@@ -21,6 +21,8 @@ class PhraseApp < Sinatra::Base
   end
  
   post '/eng-result' do
+    @lang2 = params[:language]
+    @phrase = params[:phrases]
     primary_lang("English")
     second_lang(params[:language])
     @answer = phrase_choice(params[:phrases])
@@ -28,6 +30,8 @@ class PhraseApp < Sinatra::Base
   end
   
    post '/fra-result' do
+    @lang2 = params[:language]
+    @phrase = params[:phrases]
     primary_lang("Français")
     second_lang(params[:language])
     @answer = phrase_choice(params[:phrases])
@@ -35,6 +39,8 @@ class PhraseApp < Sinatra::Base
   end
   
   post '/esp-result' do
+    @lang2 = params[:language]
+    @phrase = params[:phrases]
     primary_lang("Español")
     second_lang(params[:language])
     @answer = phrase_choice(params[:phrases])

--- a/models/phrase.rb
+++ b/models/phrase.rb
@@ -6,6 +6,7 @@
     
     #@start_lang = start
 $phrase = ""
+$lang2 = ""
     
     $en_lang_array = ["english", "spanish", "french (formal)", "french (informal)"]
     $sp_lang_array = ["inglés", "español", "francés (formal)", "francés (informal)"]
@@ -44,6 +45,8 @@ $answer = ""
   end
 
   def second_lang(choice2)
+    $lang2 = choice2
+    puts $lang2
     if choice2 == $lang_array[0]
       $phrase_answers = $en_phr_array
     elsif choice2 == $lang_array[1]
@@ -58,6 +61,8 @@ $answer = ""
   
   
   def phrase_choice(choice3)
+    $phrase = choice3
+    puts choice3
     if choice3 == $phrase_choices[0]
       $answer = $phrase_answers[0]
     elsif choice3 == $phrase_choices[1]

--- a/views/eng_result.erb
+++ b/views/eng_result.erb
@@ -6,7 +6,7 @@
   
   <center>
   <body id="result">
-    <p>The result is: <%=@answer%></p>
+    <p>"<%=@phrase%>" in <%=@lang2%> is: <%=@answer%></p>
     <br>
     <img src="http://www.wpexplorer.com/wp-content/uploads/wordpress-translation-plugins.jpg">
     <br>

--- a/views/esp_result.erb
+++ b/views/esp_result.erb
@@ -6,7 +6,7 @@
   
   <center>
   <body id="result">
-    <p>El resultado es: <%=@answer%></p>
+    <p>"<%=@phrase%>" en <%=@lang2%> es: <%=@answer%></p>
      <br>
     <img src="http://www.wpexplorer.com/wp-content/uploads/wordpress-translation-plugins.jpg">
     <br>

--- a/views/fra_result.erb
+++ b/views/fra_result.erb
@@ -6,7 +6,7 @@
   
   <center>
   <body id="result">
-    <p>Le r&eacutesultat est: <%=@answer%></p>
+    <p>"<%=@phrase%>" en <%=@lang2%> est: <%=@answer%></p>
      <br>
     <img src="http://www.wpexplorer.com/wp-content/uploads/wordpress-translation-plugins.jpg">
     <br>


### PR DESCRIPTION
I am not completely sure about the "in" translation to French. I used "en" but also found an option for "dans," but I am not sure which is more reasonable. In any case, we now have a more personalized result page than "The result is: _______"
